### PR TITLE
LAB-02-GH: Second code block is not updating the repository in-place as described

### DIFF
--- a/labs/lab_02_create_your_first_resource/github.md
+++ b/labs/lab_02_create_your_first_resource/github.md
@@ -172,7 +172,7 @@ In the `main.tf` file, update the branch protection configuration:
 
 ```hcl
 resource "github_branch_protection" "main" {
-  repository_id = github_repository.terraform.node_id
+  repository_id = github_repository.example.node_id
   pattern       = "main"
 
   required_pull_request_reviews {

--- a/labs/lab_02_create_your_first_resource/github.md
+++ b/labs/lab_02_create_your_first_resource/github.md
@@ -126,22 +126,22 @@ Let's verify our resources in the GitHub web interface:
 In the `main.tf` file, update the repository configuration:
 
 ```hcl
-resource "github_repository" "terraform" {
-  name        = "terraform-course-repo"
-  description = "Updated repository description"  # <-- change description
+resource "github_repository" "example" {
+  name        = "terraform-example"
+  description = "Updated repository description" # <-- change description
   visibility  = "public"
 
   auto_init = true
 
   has_issues      = true
   has_discussions = true
-  has_wiki        = false  # <-- change wiki setting
+  has_wiki        = false # <-- change wiki setting
 
   allow_merge_commit = true
   allow_squash_merge = true
   allow_rebase_merge = true
 
-  topics = ["terraform", "infrastructure-as-code", "learning"]  # <-- add topic
+  topics = ["terraform", "infrastructure-as-code", "learning"] # <-- add topic
 }
 ```
 


### PR DESCRIPTION
I'm working through the LAB-02-GH example. The repository is created with the first code block, then the repository _should be_ updated in place and the second code block is provided:

```hcl
resource "github_repository" "terraform" {
  name        = "terraform-course-repo"

 # ...

  topics = ["terraform", "infrastructure-as-code", "learning"]  # <-- add topic
}
```

But as the resource / repo name is different from the original code block, Terraform wants to delete the repo and re-create it with the new name. This is not the expected behaviour. This PR fixes the code example to update the repository in place as described.